### PR TITLE
Removed __main__ guard in download_genome.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ plasmids/*
 .venv
 .venv_bash
 .vscode
-ujor_lab.code-workspace
+*.code-workspace
 proj_*
 
 

--- a/genomes/genomes_refseq.txt
+++ b/genomes/genomes_refseq.txt
@@ -1,6 +1,7 @@
-Organism,ftp address
+Organism,ftp_address
 Clostridium_tyrobutyricum_KCTC_5387,ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/001/642/655/GCF_001642655.1_ASM164265v1
 Clostridium_beijerinckii_NCIMB_8052,ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/016/965/GCF_000016965.1_ASM1696v1
 Clostridium_acetobutylicum_ATCC_824,ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/008/765/GCF_000008765.1_ASM876v1
 Clostridium_pasteurianum_ATCC_6013,ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/001/856/645/GCF_001856645.1_ASM185664v1
 Clostridium_sporogenes_NCIMB_10696,ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/973/705/GCF_000973705.1_ASM97370v1
+

--- a/utility_scripts/dl_all_genomes.py
+++ b/utility_scripts/dl_all_genomes.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import subprocess
+
+os.chdir("genomes")
+genome_list = []
+with open("genomes_refseq.txt") as refseqs:
+    for line in refseqs:
+        genome_list.append(line.strip().split(","))
+
+for organism, genome_adr in genome_list[1:]:
+    print(">>> Downloading {} genome \n    from {}".format(repr(organism), repr(genome_adr)))
+    subprocess.run(["python3", "../utility_scripts/download_genome.py", "-n", organism, "-f", genome_adr, "-o", organism])

--- a/utility_scripts/download_genome.py
+++ b/utility_scripts/download_genome.py
@@ -63,7 +63,7 @@ def download_genome(ftp_address, outdir, organism=None):
             subprocess.run(makeblastdb_cmd)
 
     print(
-        "\n{} genome downloaded and formatted successfully.\nThe associated files are available in {}\n".format(
+        "\n{} genome downloaded and formatted successfully.\nThe associated files are available in genomes/{}\n".format(
             organism, outdir
         )
     )
@@ -76,33 +76,34 @@ def download_genome(ftp_address, outdir, organism=None):
 
 
 # %%
+dlgenome_parser = argparse.ArgumentParser(
+    description=script_descr,
+    fromfile_prefix_chars="@",
+    add_help=False,
+)
+dlgenome_group1 = dlgenome_parser.add_argument_group("Information to provide")
+dlgenome_group1.add_argument(
+    "-n", "--organism-name",
+    help="(Optional) Organism name. This will be used to create the output folder and rename the files associated with the downloaded genome. Words in the name should be separated by underscores, not spaces. The default value is the name of the last folder in output directory.",
+    metavar="<name>",
+)
+dlgenome_group1.add_argument(
+    "-f", "--ftp",
+    help="(Required) Ftp address of the folder containing this genome on the NCBI's server",
+    metavar="<link>",
+    required=True,
+)
+dlgenome_group1.add_argument(
+    "-o", "--outdir",
+    help="(Required) Path to the output folder (which will be created if not present). If organism name is not provided, the end folder in the directory will be used as the organism name.",
+    metavar="<path>",
+    required=True,
+)
+
 # Perform genome download if this script is called as the main script from the terminal
-if __name__ == "__main__":
-    dlgenome_parser = argparse.ArgumentParser(
-        description=script_descr,
-        fromfile_prefix_chars="@",
-        add_help=False,
-    )
-    dlgenome_group1 = dlgenome_parser.add_argument_group("Information to provide")
-    dlgenome_group1.add_argument(
-        "-n", "--organism-name",
-        help="(Optional) Organism name. This will be used to create the output folder and rename the files associated with the downloaded genome. Words in the name should be separated by underscores, not spaces. The default value is the name of the last folder in output directory.",
-        metavar="<name>",
-    )
-    dlgenome_group1.add_argument(
-        "-f", "--ftp",
-        help="(Required) Ftp address of the folder containing this genome on the NCBI's server",
-        metavar="<link>",
-        required=True,
-    )
-    dlgenome_group1.add_argument(
-        "-o", "--outdir",
-        help="(Required) Path to the output folder (which will be created if not present). If organism name is not provided, the end folder in the directory will be used as the organism name.",
-        metavar="<path>",
-        required=True,
-    )
-    if len(sys.argv) == 1:
-        dlgenome_parser.print_help()
-    else:
-        dlgenome_args = dlgenome_parser.parse_args()
-        download_genome(dlgenome_args.ftp, dlgenome_args.outdir, dlgenome_args.organism)
+# if __name__ == "__main__":
+if len(sys.argv) == 1:
+    dlgenome_parser.print_help()
+else:
+    dlgenome_args = dlgenome_parser.parse_args()
+    download_genome(dlgenome_args.ftp, dlgenome_args.outdir, dlgenome_args.organism_name)


### PR DESCRIPTION
To allow this script to be called inside a python subprocess. This was used to download multiple genomes at once through a shell script.